### PR TITLE
Fix `files` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "@types/unist": "^2.0.0",
     "hast-util-to-mdast": "^7.0.0"
   },
+  "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "devDependencies": {
     "@types/tape": "^4.0.0",


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/rehypejs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/rehypejs/.github/blob/main/support.md
https://github.com/rehypejs/.github/blob/main/contributing.md
-->
version 8.1.0 has the ability to generate typings, but does not upload the typings to npm https://unpkg.com/browse/rehype-remark@8.1.0/ , this includes the typings in the uploaded package.